### PR TITLE
Update email recipient

### DIFF
--- a/src/contact.html
+++ b/src/contact.html
@@ -63,7 +63,7 @@
 	<div id="flex-contact">
 		<div id="contact-center">
 			<form id="gform" method="POST" class="pure-form pure-form-stacked" data-email="example@email.net"
-				action="https://script.google.com/macros/s/AKfycby-q0JsA0oxDVP25I489Su-T4y-MDowo7H2DFonab6Hpf6E88E/exec">
+				action="https://script.google.com/macros/s/AKfycbyPxud1wc02hRv6izgqVZmSOQuRTTfsFHgOrcB5-FDbM-xLcj_ayqhpAyApuItYVwq7/exec">
 				<h1 id="letsTalk">Let's Talk!</h1>
 				<p id="talkP">To get a jump-start on our conversation, please fill out the questionnaire below. It only
 					takes a few minutes, and will ensure that you are contacted by just the right person. Thanks, and
@@ -115,7 +115,7 @@
 			<h4><u>Phone Number</u></h4>
 			<p>(616) 239-1234</p>
 			<h4><u>Email</u></h4>
-			<p><u style="color:red">ZeelandSelfStorage@charter.net</u></p>
+			<p><u style="color:red">ZeelandSelfStorage@gmail.com</u></p>
 			<br><br>
 			<h4><u>We Accept</u></h4>
 			<div>


### PR DESCRIPTION
### Problem / solution
The charter.net email domain was not resolving at times.  Updated google script to send emails to ZeelandSelfStorage@gmail.com + lol.karma.gg@gmail.com.  Also enabled replyTo so that reply goes to the form sumit email instead of lol.karma.gg@gmail.com.
<img width="669" alt="Screenshot 2025-06-06 at 4 29 04 PM" src="https://github.com/user-attachments/assets/b51bbc76-53d9-40b6-8361-771851d9913b" />
<img width="454" alt="Screenshot 2025-06-06 at 4 28 58 PM" src="https://github.com/user-attachments/assets/b797de80-402d-42a6-a0d3-4f906e2e3c17" />


### Tested in local. 
Email send to ZeelandSelfStorage@gmail.com + lol.karma.gg@gmail.com and reply to went to the form email.
<img width="718" alt="Screenshot 2025-06-06 at 4 31 22 PM" src="https://github.com/user-attachments/assets/a5e8e428-865f-4446-b4c9-f015a56a7155" />
### Note
I see that in the live website the contact us email already has the gmail.com email meaning some changes have been deployed w/o being pushed to this repo.  Not sure what else might be missing.